### PR TITLE
allResolved to allSettled

### DIFF
--- a/insert.ls
+++ b/insert.ls
@@ -22,7 +22,7 @@ do
     err <- p.save
     defer.resolve!
 
-<- Q.allResolved defers
+<- Q.allSettled defers
 .then
 console.log \alldone
 process.exit 0


### PR DESCRIPTION
https://github.com/kriskowal/q/blob/v1/CHANGES.md suggests that the change happened in 0.95
allResolved is deprecated, use allSettled instead. Error
    at Function.allResolved (/Users/jesse/git/today-hipster/today-hipster/node_modules/q/q.js:435:39)
